### PR TITLE
Add missing notifiers to scalingo_alert

### DIFF
--- a/scalingo/table_scalingo_alert.go
+++ b/scalingo/table_scalingo_alert.go
@@ -35,6 +35,7 @@ func tableScalingoAlert() *plugin.Table {
 			{Name: "remind_every", Type: proto.ColumnType_STRING, Description: "Send the alert at regular interval when activated."},
 			{Name: "created_at", Type: proto.ColumnType_TIMESTAMP, Description: "Creation date of the alert."},
 			{Name: "updated_at", Type: proto.ColumnType_TIMESTAMP, Description: "Last time the alert has been updated."},
+			{Name: "notifiers", Type: proto.ColumnType_JSON, Description: "Notifiers used by the alert."},
 			{Name: "metadata", Type: proto.ColumnType_JSON, Description: "Various data."},
 		},
 	}


### PR DESCRIPTION
Hello, this PR is a small improvement suggestion : 

The `scalingo_alert` table doesn't contain the notifiers id list, but this information is available via the [Scalingo API](https://developers.scalingo.com/alerts#list-alerts-of-an-app).

Even though the documentation states that the notifiers information is only available while listing all alerts, I found out that the scalingo client also returns the notifiers while fetching a specific alert via its `id`.
