### PR TITLE
quit early if using LIMIT on deployments query

### DIFF
--- a/scalingo/table_scalingo_deployment.go
+++ b/scalingo/table_scalingo_deployment.go
@@ -64,6 +64,9 @@ func listDeployment(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 			break
 		}
 		opts.Page = pagination.NextPage
+		if d.RowsRemaining(ctx) <= 0 {
+			break
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
With thousands of deployments on Scalingo, it becomes easy to hit rate limits on any join query between scalingo_deployment and scalingo_app.

This PR uses d.RowsRemaining(ctx) to check if the query is hitting its LIMIT and exits early, avoiding unnecessary iteration over all pages per scalingo_app.